### PR TITLE
Only consider a TitleDB CIA/3DSX to be installed if present in cache,…

### DIFF
--- a/source/fbi/task/listtitledb.h
+++ b/source/fbi/task/listtitledb.h
@@ -14,7 +14,6 @@ typedef struct titledb_cia_info_s {
 
     bool installed;
     bool outdated;
-    u16 installedVersion;
 } titledb_cia_info;
 
 typedef struct titledb_smdh_info_s {

--- a/source/fbi/task/uitask.c
+++ b/source/fbi/task/uitask.c
@@ -308,13 +308,11 @@ void task_draw_titledb_info_cia(ui_view* view, void* data, float x1, float y1, f
     snprintf(infoText, sizeof(infoText),
              "Title ID: %016llX\n"
                      "TitleDB Version: %s\n"
-                     "Installed Version: %hu (%d.%d.%d)\n"
                      "Size: %.2f %s\n"
                      "Updated At: %s %s\n"
                      "Update Available: %s",
              info->cia.titleId,
              info->cia.version,
-             info->cia.installedVersion, (info->cia.installedVersion >> 10) & 0x3F, (info->cia.installedVersion >> 4) & 0x3F, info->cia.installedVersion & 0xF,
              ui_get_display_size(info->cia.size), ui_get_display_size_units(info->cia.size),
              updatedDate, updatedTime,
              info->cia.outdated ? "Yes" : "No");


### PR DESCRIPTION
… remove CIA installed version field as it is not very useful for TitleDB entries.